### PR TITLE
Update serialenum.py

### DIFF
--- a/serialenum.py
+++ b/serialenum.py
@@ -23,7 +23,7 @@ def enumerate():
                 i = i + 1
             except WindowsError:
                 break
-    elif sys.platform == 'linux2':
+    elif sys.platform.startswith('linux'):
         if os.path.exists('/dev/serial/by-id'):
             entries = os.listdir('/dev/serial/by-id')
             dirs = [os.readlink(os.path.join('/dev/serial/by-id', x))


### PR DESCRIPTION
Relatively "recent" platforms like raspberry Pi4 return sys.platform="linux". While the ports name and paths are mostly the same.
Check:
https://docs.python.org/2/library/sys.html
Changed in version 2.7.3: Since lots of code check for sys.platform == 'linux2', and there is no essential change between Linux 2.x and 3.x, sys.platform is always set to 'linux2', even on Linux 3.x. In Python 3.3 and later, the value will always be set to 'linux', so it is recommended to always use the startswith ...